### PR TITLE
CU/DU crash fixes during UE Detach

### DIFF
--- a/openair2/LAYER2/MAC/eNB_scheduler.c
+++ b/openair2/LAYER2/MAC/eNB_scheduler.c
@@ -904,6 +904,12 @@ eNB_dlsch_ulsch_scheduler(module_id_t module_idP,
   }
 #endif
 
+  if (NODE_IS_DU(RC.rrc[module_idP]->node_type)) /* In case of DU, RRC should be triggered every TTI */
+  {
+    PROTOCOL_CTXT_SET_BY_MODULE_ID(&ctxt, module_idP, ENB_FLAG_YES, NOT_A_RNTI, frameP, subframeP, module_idP);
+    rrc_rx_tx(&ctxt, CC_id);
+  }
+
   for (CC_id = 0; CC_id < MAX_NUM_CCs; CC_id++) {
     if (cc[CC_id].MBMS_flag > 0) {
       start_meas(&RC.mac[module_idP]->schedule_mch);

--- a/openair2/RRC/LTE/rrc_eNB.c
+++ b/openair2/RRC/LTE/rrc_eNB.c
@@ -8868,8 +8868,17 @@ void rrc_subframe_process(protocol_ctxt_t *const ctxt_pP, const int CC_id) {
 
         if ((rrc_release_info.RRC_release_ctrl[release_num].flag > 2) &&
             (rrc_release_info.RRC_release_ctrl[release_num].rnti == ue_context_p->ue_context.rnti)) {
-          ue_context_p->ue_context.ue_release_timer_rrc = 1;
-          ue_context_p->ue_context.ue_release_timer_thres_rrc = 100;
+
+	      if (ue_context_p->ue_context.ue_release_timer_rrc == 0) /*setting ue_release_timer_rrc for the first time only */
+          {
+            ue_context_p->ue_context.ue_release_timer_rrc = 1;
+            ue_context_p->ue_context.ue_release_timer_thres_rrc = 100;
+          }
+				
+          LOG_D(RRC, "[%s,%u] Rel_num %d RNTI %x,%x:Flag %d ue_release_timer_rrc %d\n",
+			__func__,__LINE__, release_num, rrc_release_info.RRC_release_ctrl[release_num].rnti,
+			ue_context_p->ue_context.rnti, rrc_release_info.RRC_release_ctrl[release_num].flag,
+			ue_context_p->ue_context.ue_release_timer_rrc);
 
           if (EPC_MODE_ENABLED && !NODE_IS_DU(RC.rrc[ctxt_pP->module_id]->node_type)) {
             if (rrc_release_info.RRC_release_ctrl[release_num].flag == 4) { // if timer_s1 == 0

--- a/openair2/RRC/LTE/rrc_eNB_UE_context.c
+++ b/openair2/RRC/LTE/rrc_eNB_UE_context.c
@@ -199,6 +199,23 @@ void rrc_eNB_remove_ue_context(
     ue_context_pP->ue_context.rnti);
   rrc_eNB_free_mem_UE_context(ctxt_pP, ue_context_pP);
   uid_linear_allocator_free(rrc_instance_pP, ue_context_pP->local_uid);
+
+  if (NODE_IS_CU(rrc_instance_pP->node_type))
+  {
+    for (uint16_t release_num = 0; release_num < NUMBER_OF_UE_MAX; release_num++) 
+    {
+      if ((rrc_release_info.RRC_release_ctrl[release_num].flag > 0) &&
+          (rrc_release_info.RRC_release_ctrl[release_num].rnti == ue_context_pP->ue_context.rnti)) 
+      {
+        rrc_release_info.RRC_release_ctrl[release_num].flag = 0;
+        rrc_release_info.num_UEs--;
+        LOG_D(RRC,"******* CU RRC Rel info Reset ! rel_num:%d numUE:%d RNTI:%x *********** \n",
+              release_num, rrc_release_info.num_UEs, ue_context_pP->ue_context.rnti);
+        break;
+      }
+    }
+  }
+  
   free(ue_context_pP);
   rrc_instance_pP->Nb_ue --;
   LOG_I(RRC,


### PR DESCRIPTION
Fix Description:
1. RRC of DU was not getting triggered in each TTI, due to which it was not functional and hence UE RRC Release flags were not getting cleared at the time of detach
2. In DU, RRC UE context cleaning timer was getting reset before expiry, due to which UE context was not getting deleted even after UE release
3. In CU, RRC was not re-setting UE RRC Release flags when UE context was getting deleted (during UE detach procedure)