### PR TITLE
CU/DU crash & stale UE Cntx fixes

### DIFF
--- a/openair2/F1AP/f1ap_common.c
+++ b/openair2/F1AP/f1ap_common.c
@@ -75,7 +75,8 @@ int f1ap_add_ue(f1ap_cudu_inst_t    *f1_inst,
     if (f1_inst->f1ap_ue[i].rnti == rntiP) {
       f1_inst->f1ap_ue[i].f1ap_uid = i;
       f1_inst->f1ap_ue[i].mac_uid = UE_id;
-      LOG_I(F1AP, "Updating the index of UE with RNTI %x and du_ue_f1ap_id %d\n", f1_inst->f1ap_ue[i].rnti, f1_inst->f1ap_ue[i].du_ue_f1ap_id);
+      LOG_E(F1AP, "Updating the index of UE with RNTI %x and du_ue_f1ap_id %d instance %d\n", 
+		  f1_inst->f1ap_ue[i].rnti, f1_inst->f1ap_ue[i].du_ue_f1ap_id, module_idP);
       return i;
     }
   }
@@ -95,8 +96,12 @@ int f1ap_add_ue(f1ap_cudu_inst_t    *f1_inst,
       }
 #endif
 
-      LOG_I(F1AP, "Adding a new UE with RNTI %x and cu/du ue_f1ap_id %d\n", f1_inst->f1ap_ue[i].rnti, f1_inst->f1ap_ue[i].du_ue_f1ap_id);
+      LOG_E(F1AP, "Adding a new UE with RNTI %x and cu/du ue_f1ap_id %d instance %d\n", 
+		  f1_inst->f1ap_ue[i].rnti, f1_inst->f1ap_ue[i].du_ue_f1ap_id, module_idP);
       return i;
+    } else {
+      LOG_E(F1AP, "FAILED[%d]: Adding a new UE with RNTI %x existing RNTI %x instance %d\n", 
+		  i, rntiP, f1_inst->f1ap_ue[i].rnti, module_idP);
     }
   }
   return -1;
@@ -104,15 +109,30 @@ int f1ap_add_ue(f1ap_cudu_inst_t    *f1_inst,
 
 
 int f1ap_remove_ue(f1ap_cudu_inst_t *f1_inst,
-                   rnti_t            rntiP) {
-  for (int i = 0; i < MAX_MOBILES_PER_ENB; i++) {
-    if (f1_inst->f1ap_ue[i].rnti == rntiP) {
+                   rnti_t            rntiP) 
+{
+  unsigned int found = 0;
+  int i;
+
+  for (i = 0; i < MAX_MOBILES_PER_ENB; i++) 
+  {
+    if (f1_inst->f1ap_ue[i].rnti == rntiP) 
+    {
+      LOG_E(F1AP, "FOUND: Removing UE with RNTI %x f1_inst->f1ap_ue[%d].rnti %x\n", 
+				 rntiP, i, f1_inst->f1ap_ue[i].rnti);
       f1_inst->f1ap_ue[i].rnti = 0;
+      found = 1;
       break;
     }
+    LOG_E(F1AP, "FAILED: Removing UE with RNTI %x f1_inst->f1ap_ue[%d].rnti %x\n", 
+				rntiP, i, f1_inst->f1ap_ue[i].rnti);
   }
-  f1_inst->num_ues--;
-  return 0;
+
+  if (found == 1)
+  {
+    f1_inst->num_ues--;
+  }
+  return i;
 }
 
 int f1ap_get_du_ue_f1ap_id(f1ap_cudu_inst_t *f1_inst,

--- a/openair2/F1AP/f1ap_cu_ue_context_management.c
+++ b/openair2/F1AP/f1ap_cu_ue_context_management.c
@@ -826,6 +826,19 @@ int CU_handle_UE_CONTEXT_RELEASE_REQUEST(instance_t       instance,
   LOG_I(F1AP, "Received UE CONTEXT RELEASE REQUEST: Trigger RRC for RNTI %x\n", rnti);
   struct rrc_eNB_ue_context_s *ue_context_pP;
   ue_context_pP = rrc_eNB_get_ue_context(RC.rrc[instance], rnti);
+
+  /* Received F1AP UE Ctx Rel Req from DU, now prepare to send
+   * F1AP UE Ctx Rel Complete, without this precedure F1AP contexts
+   * at CU & DU will not get deleted
+   */
+  MessageDef *m = itti_alloc_new_message(TASK_RRC_ENB, F1AP_UE_CONTEXT_RELEASE_CMD);
+  F1AP_UE_CONTEXT_RELEASE_CMD(m).rnti = rnti;
+  F1AP_UE_CONTEXT_RELEASE_CMD(m).cause = F1AP_CAUSE_RADIO_NETWORK;
+  F1AP_UE_CONTEXT_RELEASE_CMD(m).cause_value = 10; // 10 = F1AP_CauseRadioNetwork_normal_release
+  F1AP_UE_CONTEXT_RELEASE_CMD(m).rrc_container = NULL;
+  F1AP_UE_CONTEXT_RELEASE_CMD(m).rrc_container_length = 0;
+  itti_send_msg_to_task(TASK_CU_F1, instance, m);
+
   rrc_eNB_send_S1AP_UE_CONTEXT_RELEASE_REQ(
       instance,
       ue_context_pP,

--- a/openair2/F1AP/f1ap_du_rrc_message_transfer.c
+++ b/openair2/F1AP/f1ap_du_rrc_message_transfer.c
@@ -106,6 +106,13 @@ int DU_handle_DL_RRC_MESSAGE_TRANSFER(instance_t       instance,
   LOG_D(F1AP, "du_ue_f1ap_id %lu associated with UE RNTI %x \n",
         du_ue_f1ap_id,
         f1ap_get_rnti_by_du_id(&f1ap_du_inst[instance], du_ue_f1ap_id)); // this should be the one transmitted via initial ul rrc message transfer
+  
+  /* Check if UE RNTI is valid or not */
+  if (f1ap_get_rnti_by_du_id(&f1ap_du_inst[instance],du_ue_f1ap_id) == 0) {
+    LOG_E(F1AP, "++++++ UE with du-id:%lu cu-id:%lu already deleted,dropping msg !!! +++++++\n",
+          du_ue_f1ap_id, cu_ue_f1ap_id);
+    return -1;
+ }
 
   if (f1ap_du_add_cu_ue_id(&f1ap_du_inst[instance],du_ue_f1ap_id, cu_ue_f1ap_id) < 0 ) {
     LOG_E(F1AP, "Failed to find the F1AP UID \n");

--- a/openair2/F1AP/f1ap_du_ue_context_management.c
+++ b/openair2/F1AP/f1ap_du_ue_context_management.c
@@ -642,6 +642,7 @@ int DU_handle_UE_CONTEXT_RELEASE_COMMAND(instance_t       instance,
 
   /* We don't need the Cause */
   /* Optional RRC Container: if present, send to UE */
+#if 0
   F1AP_FIND_PROTOCOLIE_BY_ID(F1AP_UEContextReleaseCommandIEs_t, ie, container,
                              F1AP_ProtocolIE_ID_id_RRCContainer, false);
 
@@ -685,6 +686,7 @@ int DU_handle_UE_CONTEXT_RELEASE_COMMAND(instance_t       instance,
         break;
     }
   }
+#endif
 
   struct rrc_eNB_ue_context_s *ue_context_p;
 
@@ -822,6 +824,9 @@ int DU_send_UE_CONTEXT_RELEASE_COMPLETE(instance_t instance,
                                   buffer,
                                   len,
                                   f1ap_du_data->default_sctp_stream_id);
+    
+  LOG_I(F1AP, " ***** REMOVING UE RNTI:%d from F1AP******\n", cplt->rnti);
+  
   f1ap_remove_ue(&f1ap_du_inst[instance], cplt->rnti);
   return 0;
 }

--- a/openair2/LAYER2/MAC/eNB_scheduler_dlsch.c
+++ b/openair2/LAYER2/MAC/eNB_scheduler_dlsch.c
@@ -425,8 +425,8 @@ void ue_rrc_release(rnti_t rnti) {
       for (uint16_t mui_num = 0; mui_num < rlc_am_mui.rrc_mui_num; mui_num++) {
         if(release_ctrl->rrc_eNB_mui == rlc_am_mui.rrc_mui[mui_num]) {
           release_ctrl->flag = 4;
-          LOG_D(MAC, "DLSCH Release send:index %d rnti %x mui %d mui_num %d flag 2->4\n",
-                n,
+          LOG_I(MAC, "[%s] DLSCH Release send:index %d rnti %x mui %d mui_num %d flag 2->4\n",
+                __func__, n,
                 rnti,
                 rlc_am_mui.rrc_mui[mui_num],
                 mui_num);

--- a/openair2/LAYER2/MAC/eNB_scheduler_ulsch.c
+++ b/openair2/LAYER2/MAC/eNB_scheduler_ulsch.c
@@ -155,6 +155,14 @@ rx_sdu(const module_id_t enb_mod_idP,
     AssertFatal(UE_scheduling_control->round_UL[CC_idP][harq_pid] < 8, "round >= 8\n");
 
     if (sduP != NULL) {
+     
+      if ( (UE_scheduling_control->ul_failure_timer > 0) || (UE_scheduling_control->ul_out_of_sync > 0) || (UE_scheduling_control->ul_consecutive_errors))//(UE_scheduling_control->ul_inactivity_timer > 0) )
+      {
+          LOG_I(MAC, "====== RNTI:%x Resetting UL-F-Timer[%d] & UL-out-of-syn[%d] cons-err[%d] Inactive-Timer[%d] ======= \n", 
+                      current_rnti, UE_scheduling_control->ul_failure_timer, UE_scheduling_control->ul_out_of_sync, 
+                      UE_scheduling_control->ul_consecutive_errors, UE_scheduling_control->ul_inactivity_timer);
+      }
+
       UE_scheduling_control->ul_inactivity_timer = 0;
       UE_scheduling_control->ul_failure_timer = 0;
       UE_scheduling_control->ul_scheduled &= (~(1 << harq_pid));
@@ -180,7 +188,7 @@ rx_sdu(const module_id_t enb_mod_idP,
         UE_template_ptr->scheduled_ul_bytes = 0;
       }
     } else {  // sduP == NULL => error
-      LOG_W(MAC, "[eNB %d][PUSCH %d] CC_id %d %d.%d ULSCH in error in round %d, ul_cqi %d, UE_id %d, RNTI %x (len %d)\n",
+      LOG_W(MAC, "[eNB %d][PUSCH %d] CC_id %d %d.%d ULSCH Error round %d ul_cqi %d UE_id %d RNTI %x len %d UL-F-Timer[%d] Cons-err[%d]\n",
             enb_mod_idP,
             harq_pid,
             CC_idP,
@@ -190,7 +198,9 @@ rx_sdu(const module_id_t enb_mod_idP,
             ul_cqi,
             UE_id,
             current_rnti,
-	    sdu_lenP);
+            sdu_lenP,
+            UE_scheduling_control->ul_failure_timer,
+            UE_scheduling_control->ul_consecutive_errors);
 
       if (ul_cqi > 200) { // too high energy pattern
         UE_scheduling_control->pusch_snr[CC_idP] = ul_cqi;
@@ -202,6 +212,7 @@ rx_sdu(const module_id_t enb_mod_idP,
         UE_scheduling_control->round_UL[CC_idP][harq_pid] = 0;
 
         if (UE_scheduling_control->ul_consecutive_errors++ == 10) {
+          LOG_E(MAC, " ++++++++  RNTI:%x Due to Consecutive Errors Setting UL-F-Timer to 1 +++++++++ \n", current_rnti);
           UE_scheduling_control->ul_failure_timer = 1;
         }
 

--- a/openair2/LAYER2/rlc_v2/rlc_oai_api.c
+++ b/openair2/LAYER2/rlc_v2/rlc_oai_api.c
@@ -298,6 +298,7 @@ rlc_op_status_t rlc_data_req     (const protocol_ctxt_t *const ctxt_pP,
   int rnti = ctxt_pP->rnti;
   rlc_ue_t *ue;
   rlc_entity_t *rb;
+  rlc_op_status_t ret;
 
   if (MBMS_flagP == MBMS_FLAG_YES)
     rnti = 0xfffd;
@@ -331,16 +332,20 @@ rlc_op_status_t rlc_data_req     (const protocol_ctxt_t *const ctxt_pP,
   if (rb != NULL) {
     rb->set_time(rb, rlc_current_time);
     rb->recv_sdu(rb, (char *)sdu_pP->data, sdu_sizeP, muiP);
+    ret = RLC_OP_STATUS_OK;
   } else {
     LOG_E(RLC, "%s:%d:%s: fatal: SDU sent to unknown RB\n", __FILE__, __LINE__, __FUNCTION__);
-    exit(1);
+    rlc_manager_remove_ue(rlc_ue_manager, rnti);
+    ret = RLC_OP_STATUS_BAD_PARAMETER; 
+    //exit(1);
   }
 
   rlc_manager_unlock(rlc_ue_manager);
 
   free_mem_block(sdu_pP, __func__);
 
-  return RLC_OP_STATUS_OK;
+  //return RLC_OP_STATUS_OK;
+  return ret;
 }
 
 int rlc_module_init(int enb_flag)

--- a/openair2/RRC/LTE/L2_interface.c
+++ b/openair2/RRC/LTE/L2_interface.c
@@ -150,7 +150,7 @@ mac_rrc_data_req(
                                      (void *)mib,
                                      carrier->MIB,
                                      24);
-    LOG_D(RRC,"Encoded MIB for frame %d (%p), bits %lu\n",sfn,carrier->MIB,enc_rval.encoded);
+    //LOG_D(RRC,"Encoded MIB for frame %d (%p), bits %lu\n",sfn,carrier->MIB,enc_rval.encoded);
     buffer_pP[0]=carrier->MIB[0];
     buffer_pP[1]=carrier->MIB[1];
     buffer_pP[2]=carrier->MIB[2];
@@ -327,7 +327,7 @@ mac_eNB_get_rrc_status(
   }
 }
 
-void mac_eNB_rrc_ul_failure(const module_id_t Mod_instP,
+int mac_eNB_rrc_ul_failure(const module_id_t Mod_instP,
                             const int CC_idP,
                             const frame_t frameP,
                             const sub_frame_t subframeP,
@@ -336,6 +336,7 @@ void mac_eNB_rrc_ul_failure(const module_id_t Mod_instP,
   ue_context_p = rrc_eNB_get_ue_context(
                    RC.rrc[Mod_instP],
                    rntiP);
+  int ret = 0;
 
   if (ue_context_p != NULL) {
     LOG_I(RRC,"Frame %d, Subframe %d: UE %x UL failure, activating timer\n",frameP,subframeP,rntiP);
@@ -344,6 +345,7 @@ void mac_eNB_rrc_ul_failure(const module_id_t Mod_instP,
       ue_context_p->ue_context.ul_failure_timer=1;
   } else {
     LOG_W(RRC,"Frame %d, Subframe %d: UL failure: UE %x unknown \n",frameP,subframeP,rntiP);
+    ret = -1;
   }
 
   if (flexran_agent_get_rrc_xface(Mod_instP)) {
@@ -351,6 +353,7 @@ void mac_eNB_rrc_ul_failure(const module_id_t Mod_instP,
         rntiP, PROTOCOL__FLEX_UE_STATE_CHANGE_TYPE__FLUESC_DEACTIVATED);
   }
 
+  return ret;
   //rrc_mac_remove_ue(Mod_instP,rntiP);
 }
 

--- a/openair2/RRC/LTE/rrc_eNB_UE_context.c
+++ b/openair2/RRC/LTE/rrc_eNB_UE_context.c
@@ -209,7 +209,7 @@ void rrc_eNB_remove_ue_context(
       {
         rrc_release_info.RRC_release_ctrl[release_num].flag = 0;
         rrc_release_info.num_UEs--;
-        LOG_D(RRC,"******* CU RRC Rel info Reset ! rel_num:%d numUE:%d RNTI:%x *********** \n",
+        LOG_E(RRC,"******* CU RRC Rel info Reset ! rel_num:%d numUE:%d RNTI:%x *********** \n",
               release_num, rrc_release_info.num_UEs, ue_context_pP->ue_context.rnti);
         break;
       }

--- a/openair2/RRC/LTE/rrc_proto.h
+++ b/openair2/RRC/LTE/rrc_proto.h
@@ -476,7 +476,7 @@ mac_rrc_data_ind_ue(
 
 void mac_sync_ind( module_id_t Mod_instP, uint8_t status);
 
-void mac_eNB_rrc_ul_failure(const module_id_t Mod_instP,
+int mac_eNB_rrc_ul_failure(const module_id_t Mod_instP,
                             const int CC_id,
                             const frame_t frameP,
                             const sub_frame_t subframeP,


### PR DESCRIPTION
Below is the list of fixes done as part of this commit:
1. DU Crash fix during SRB0 handling
2. DU(RLC) exit fix during SRB1 handling
3. Stale UE context fixes at CU (F1AP/RRC/PDCP/S1AP) & DU(MAC/RLC/RRC/F1AP) : 
> During RLC Max retransmission
> During Msg4 retransmission
> During UL-SCH consecutive error (HARQ exhaustion)
> During graceful UE detach
> During Radio Link failure (detected at MAC) due to UL-Failure