### PR TITLE
Default Slicing support

### DIFF
--- a/cmake_targets/CMakeLists.txt
+++ b/cmake_targets/CMakeLists.txt
@@ -1129,6 +1129,10 @@ add_library(PROTO_AGENT
 set(PROTO_AGENT_LIB PROTO_AGENT)
 include_directories(${OPENAIR2_DIR}/LAYER2/PROTO_AGENT)
 
+# RAN SLICING
+#################
+add_boolean_option(ENABLE_RAN_SLICING False "Enable RAN Slicing")
+
 # O-RAN RIC Agent
 #################
 add_boolean_option(ENABLE_RIC_AGENT False "Enable O-RAN RIC agent")

--- a/cmake_targets/build_oai
+++ b/cmake_targets/build_oai
@@ -66,6 +66,7 @@ UE_DEBUG_TRACE="False"
 UE_TIMING_TRACE="False"
 USRP_REC_PLAY="False"
 BUILD_RIC_AGENT="False"
+BUILD_RAN_SLICING="False"
 RIC_GENERATED_E2AP_BINDING_DIR=""
 RIC_GENERATED_E2SM_BINDING_DIR=""
 BUILD_ECLIPSE=0
@@ -415,6 +416,10 @@ function main() {
             SKIP_SHARED_LIB_FLAG="True"
             echo_info "Skipping build of shared libraries, rfsimulator and transport protocol libraries"
             shift;;
+    --build-ran-slicing)
+        BUILD_RAN_SLICING="True"
+        echo_info "Enabling RAN Slicing"
+        shift;;
     --ninja)
         CMAKE_CMD="$CMAKE_CMD -GNinja"
 	MAKE_CMD=ninja
@@ -605,6 +610,7 @@ function main() {
     echo "set ( UE_TIMING_TRACE $UE_TIMING_TRACE )"                       >> $cmake_file
     echo "set ( USRP_REC_PLAY $USRP_REC_PLAY )"                           >> $cmake_file
     echo "set ( ENABLE_RIC_AGENT $BUILD_RIC_AGENT )"                      >> $cmake_file
+    echo "set ( ENABLE_RAN_SLICING $BUILD_RAN_SLICING )"                  >> $cmake_file
     echo "set ( SKIP_SHARED_LIB_FLAG $SKIP_SHARED_LIB_FLAG )"             >> $cmake_file
     echo 'include(${CMAKE_CURRENT_SOURCE_DIR}/../CMakeLists.txt)'         >> $cmake_file
     cd  $DIR/$build_dir/build

--- a/openair1/SCHED/prach_procedures.c
+++ b/openair1/SCHED/prach_procedures.c
@@ -104,7 +104,7 @@ void prach_procedures(PHY_VARS_eNB *eNB,
         max_preamble_energy[0]/10,
         max_preamble_delay[0],
         eNB->prach_energy_counter,
-        eNB->measurements.prach_I0+eNB->prach_DTX_threshold+50,
+        eNB->measurements.prach_I0+eNB->prach_DTX_threshold+60,
         eNB->measurements.prach_I0);
 
   if (br_flag==1) {
@@ -147,7 +147,7 @@ void prach_procedures(PHY_VARS_eNB *eNB,
     } */// ce_level
   } else {
     if ((eNB->prach_energy_counter == 100) &&
-        (max_preamble_energy[0] > (eNB->measurements.prach_I0+eNB->prach_DTX_threshold+50) )) {
+        (max_preamble_energy[0] > (eNB->measurements.prach_I0+eNB->prach_DTX_threshold+60) )) {
       LOG_I(PHY,"[eNB %d/%d][RAPROC] Frame %d, subframe %d Initiating RA procedure with preamble %d, energy %d.%d dB, delay %d\n",
             eNB->Mod_id,
             eNB->CC_id,

--- a/openair2/ENB_APP/MESSAGES/V2/config_common.proto
+++ b/openair2/ENB_APP/MESSAGES/V2/config_common.proto
@@ -70,6 +70,7 @@ enum flex_slice_algorithm {
 message flex_slice_static {
   optional uint32 posLow = 1;
   optional uint32 posHigh = 2;
+  optional uint32 timeSchd = 3;
 }
 
 message flex_slice {

--- a/openair2/ENB_APP/flexran_agent_ran_api.c
+++ b/openair2/ENB_APP/flexran_agent_ran_api.c
@@ -3025,10 +3025,12 @@ Protocol__FlexSliceAlgorithm flexran_get_dl_slice_algo(mid_t mod_id) {
   }
 }
 
-int flexran_set_dl_slice_algo(mid_t mod_id, Protocol__FlexSliceAlgorithm algo) {
+int flexran_set_dl_slice_algo(mid_t mod_id, Protocol__FlexSliceAlgorithm algo) 
+{
   if (!mac_is_present(mod_id)) return 0;
   eNB_MAC_INST *mac = RC.mac[mod_id];
   const int cc_id = 0;
+  LOG_I(FLEXRAN_AGENT, "[%s]algorithm %d\n", __func__, algo);
 
   pp_impl_param_t dl = mac->pre_processor_dl;
   switch (algo) {
@@ -3042,10 +3044,14 @@ int flexran_set_dl_slice_algo(mid_t mod_id, Protocol__FlexSliceAlgorithm algo) {
       mac->pre_processor_dl.slices = NULL;
       break;
   }
+  LOG_I(FLEXRAN_AGENT, "[%s] Destrying Slice \n", __func__);
   if (dl.slices)
     dl.destroy(&dl.slices);
   if (dl.dl_algo.data)
     dl.dl_algo.unset(&dl.dl_algo.data);
+
+  slice_info_t *si = RC.mac[mod_id]->pre_processor_dl.slices;
+  LOG_I(FLEXRAN_AGENT, "[%s]After Destroy si->num:%d\n",__func__,si->num);
   return 1;
 }
 
@@ -3116,7 +3122,8 @@ void flexran_set_ue_ul_slice_id(mid_t mod_id, mid_t ue_id, slice_id_t slice_id) 
   ul->move_UE(ul->slices, ue_id, idx);
 }
 
-int flexran_create_dl_slice(mid_t mod_id, const Protocol__FlexSlice *s) {
+int flexran_create_dl_slice(mid_t mod_id, const Protocol__FlexSlice *s) 
+{
   if (!mac_is_present(mod_id)) return 0;
   void *params = NULL;
   switch (s->params_case) {
@@ -3125,6 +3132,7 @@ int flexran_create_dl_slice(mid_t mod_id, const Protocol__FlexSlice *s) {
       if (!params) return 0;
       ((static_slice_param_t *)params)->posLow = s->static_->poslow;
       ((static_slice_param_t *)params)->posHigh = s->static_->poshigh;
+      ((static_slice_param_t *)params)->timeSchd = s->static_->timeschd;
       break;
     default:
       break;
@@ -3132,6 +3140,9 @@ int flexran_create_dl_slice(mid_t mod_id, const Protocol__FlexSlice *s) {
   pp_impl_param_t *dl = &RC.mac[mod_id]->pre_processor_dl;
   char *l = s->label ? strdup(s->label) : NULL;
   void *algo = &dl->dl_algo; // default scheduler
+  
+  LOG_I(FLEXRAN_AGENT, "[%s]Algo algo:%s\n",__func__, ((default_sched_dl_algo_t *)algo)->name);
+#if 0
   if (s->scheduler) {
     algo = dlsym(NULL, s->scheduler);
     if (!algo) {
@@ -3140,6 +3151,10 @@ int flexran_create_dl_slice(mid_t mod_id, const Protocol__FlexSlice *s) {
       return -15;
     }
   }
+  LOG_I(FLEXRAN_AGENT, "[%s]After  algo:%s\n",__func__, ((default_sched_dl_algo_t *)algo)->name);
+#endif
+
+  LOG_I(FLEXRAN_AGENT, "[%s]Creating DL Slice ID:%d Label:%s \n",__func__, s->id, l);
   return dl->addmod_slice(dl->slices, s->id, l, algo, params);
 }
 
@@ -3151,12 +3166,20 @@ int flexran_remove_dl_slice(mid_t mod_id, const Protocol__FlexSlice *s) {
   return dl->remove_slice(dl->slices, idx);
 }
 
-int flexran_find_dl_slice(mid_t mod_id, slice_id_t slice_id) {
+int flexran_find_dl_slice(mid_t mod_id, slice_id_t slice_id) 
+{
   if (!mac_is_present(mod_id)) return -1;
   slice_info_t *si = RC.mac[mod_id]->pre_processor_dl.slices;
   for (int i = 0; i < si->num; ++i)
+  {
     if (si->s[i]->id == slice_id)
+    {
+      LOG_I(FLEXRAN_AGENT, "[%s]Found si->num:%d slice_id:%d i:%d\n",__func__, si->num, slice_id,i);
       return i;
+    }
+  }
+
+  LOG_I(FLEXRAN_AGENT, "[%s]Could not find si->num:%d slice_id:%d\n",__func__, si->num, slice_id);
   return -1;
 }
 

--- a/openair2/LAYER2/MAC/slicing/slicing.h
+++ b/openair2/LAYER2/MAC/slicing/slicing.h
@@ -63,9 +63,12 @@ int slicing_get_UE_slice_idx(slice_info_t *si, int UE_id);
 #define STATIC_SLICING 10
 /* only four static slices for UL, DL resp. (not enough DCIs) */
 #define MAX_STATIC_SLICES 4
+#define MAX_DED_SLICE_TIME_SCHD 80
+#define MAX_DEF_SLICE_TIME_SCHD 100
 typedef struct {
   uint16_t posLow;
   uint16_t posHigh;
+  uint16_t timeSchd;
 } static_slice_param_t;
 pp_impl_param_t static_dl_init(module_id_t mod_id, int CC_id);
 pp_impl_param_t static_ul_init(module_id_t mod_id, int CC_id);


### PR DESCRIPTION
- These code changes will enable default slicing support in DU. DU will configure the default slice at the time of bootup and all UEs getting attached will be associated to default slice
- "--build-ran-slicing" build option is introduced to optionally build RAN Slicing logic in DU 
- code changes are tested w/ & w/o ran slicing logic, no impact observed to "--build-ric-agent"