### PR TITLE
Update sctp_eNB_task.c

### DIFF
--- a/openair3/SCTP/sctp_eNB_task.c
+++ b/openair3/SCTP/sctp_eNB_task.c
@@ -609,6 +609,7 @@ sctp_handle_new_association_req(
     SCTP_DEBUG("Inserted new descriptor for sd %d in list, nb elements %u, assoc_id %d\n",
                sd, sctp_nb_cnx, assoc_id);
 }
+}
 
 //------------------------------------------------------------------------------
 void sctp_send_data(


### PR DESCRIPTION
added closing bracket to the sctp_handle_new_association_req function in sctp_eNB_task.c which it was lacking.