### PR TITLE
Fix: prevent mixed libuhd versions in build_helper (Ubuntu 18.04)

### DIFF
--- a/openairinterface5g/cmake_targets/tools/build_helper
+++ b/openairinterface5g/cmake_targets/tools/build_helper
@@ -349,7 +349,7 @@ check_install_usrp_uhd_driver(){
             $SUDO apt-get -y install libuhd-dev libuhd3.15.0 uhd-host
             ;;
           "ubuntu18.04" | "ubuntu20.04" | "ubuntu22.04")
-            $SUDO apt-get -y install libuhd-dev libuhd4.2.0 uhd-host
+            $SUDO apt-get -y install libuhd-dev libuhd003 uhd-host
             ;;
         esac
     elif [[ "$OS_BASEDISTRO" == "fedora" ]]; then


### PR DESCRIPTION
This PR fixes an issue in the build_helper script where mixed UHD library versions could be installed on Ubuntu 18.04 systems.